### PR TITLE
Fix Documentation Link On The Home Page

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,6 @@ last_modified_date: 2022-05-23
 
 Welcome to Pistol Shrimp's documentation. Docs for [Simple]({% link pages/simple/simple.md %}) can be found here.
 
-If you would like to contribute to the documentation, please feel free to submit a pull request to the [documentation repo](https://github.com/pistolshrimpgames/psitolshrimpgames.github.io).
+If you would like to contribute to the documentation, please feel free to submit a pull request to the [documentation repo](https://github.com/pistolshrimpgames/pistolshrimpgames.github.io).
 
 Want to learn more about Pistol Shrimp? Visit us at <https://pistolshrimpgames.com>.


### PR DESCRIPTION
The documentation link on the home page has a typo. And it's not working.

Before:
https://github.com/pistolshrimpgames/psitolshrimpgames.github.io

After: 
https://github.com/pistolshrimpgames/pistolshrimpgames.github.io



